### PR TITLE
Add commune-mcp — email infrastructure for AI agents

### DIFF
--- a/servers/commune-mcp.yaml
+++ b/servers/commune-mcp.yaml
@@ -1,0 +1,38 @@
+id: commune-mcp
+name: Commune MCP
+description: >-
+  Email infrastructure for AI agents. Provision inboxes programmatically,
+  send and receive email, manage threads across concurrent conversations,
+  use custom sending domains, handle attachments, run structured extraction
+  on inbound mail, and send/receive SMS — all from a single MCP server.
+author: commune-sh
+url: https://github.com/commune-sh/commune-mcp
+category: communication
+tags:
+  - email
+  - agent-email
+  - inbox
+  - sms
+  - structured-extraction
+  - communication
+installations:
+  - name: UVX
+    config: |-
+      {
+        "command": "uvx",
+        "args": ["commune-mcp"],
+        "env": {
+          "COMMUNE_API_KEY": "${COMMUNE_API_KEY}"
+        }
+      }
+    prerequisites:
+      - Python 3.10+
+      - uv (https://docs.astral.sh/uv/)
+    parameters:
+      - name: Commune API Key
+        key: COMMUNE_API_KEY
+        placeholder: comm_your_api_key_here
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Adding Commune MCP to the communication category.

It's email infrastructure for agents rather than humans — the main distinction being that you provision inboxes programmatically (rather than connecting to an existing Gmail), threads are tracked natively across concurrent conversations so the agent doesn't lose context, and inbound mail comes back as structured data rather than raw HTML.

The YAML uses UVX for installation which is consistent with how Python-based MCP servers are typically distributed — no global pip install, no venv setup, just `uvx commune-mcp` and an API key.

happy to update any fields if the schema has changed since the apify.yaml template.