### PR TITLE
Add agentic-ads server

### DIFF
--- a/servers/agentic-ads.yaml
+++ b/servers/agentic-ads.yaml
@@ -1,0 +1,37 @@
+id: agentic_ads
+name: Agentic Ads
+description: >-
+  Ad monetization SDK for MCP servers. Earn 70% revenue share on contextual
+  affiliate ads served through MCP tools. Like AdSense for AI agents.
+author: nicofains1
+url: https://github.com/nicofains1/agentic-ads
+license: MIT
+category: marketing
+tags:
+  - advertising
+  - monetization
+  - affiliate
+  - mcp-sdk
+installations:
+  - name: Remote
+    description: Connect to the hosted MCP endpoint
+    config: |-
+      {
+        "url": "https://agentic-ads-production.up.railway.app/mcp",
+        "transport": "http"
+      }
+    transports:
+      - streamable-http
+  - name: NPX
+    description: Run locally via npx
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "agentic-ads"]
+      }
+    prerequisites:
+      - Node.js >= 22
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Adds agentic-ads to the registry.

**agentic-ads** is an ad monetization SDK for MCP servers. MCP server developers add a few lines of code and earn 70% revenue share on contextual affiliate ads.

Two installation methods included:
- **Remote**: Connect to the hosted endpoint at `https://agentic-ads-production.up.railway.app/mcp` (streamable-http)
- **NPX**: Run locally via `npx agentic-ads` (stdio)

- MIT licensed
- 270 tests passing
- Published on npm as `agentic-ads`
- GitHub: https://github.com/nicofains1/agentic-ads