### PR TITLE
Add chainlink-sentinel server

### DIFF
--- a/servers/chainlink_sentinel.yaml
+++ b/servers/chainlink_sentinel.yaml
@@ -1,0 +1,30 @@
+id: chainlink_sentinel
+name: Chainlink Sentinel
+description: >-
+  AI-powered cross-chain risk sentinel using Chainlink Data Feeds. 6 MCP tools
+  for real-time oracle monitoring, anomaly detection, stablecoin depeg alerts,
+  and AI risk reports across 6 EVM chains. Zero API keys required.
+author: ElromEvedElElyon
+url: https://github.com/ElromEvedElElyon/chainlink-sentinel
+category: blockchain
+tags:
+  - chainlink
+  - oracle
+  - defi
+  - risk-monitoring
+  - cross-chain
+  - security
+installations:
+  - name: NPX from GitHub
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "github:ElromEvedElElyon/chainlink-sentinel"]
+      }
+    prerequisites:
+      - Node.js
+    parameters: []
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Add chainlink-sentinel - AI-powered cross-chain risk sentinel using Chainlink Data Feeds. 6 MCP tools, 30+ feeds, 6 EVM chains. Zero API keys. Source: https://github.com/ElromEvedElElyon/chainlink-sentinel