### PR TITLE
Add flash-payment-system — bUSD1 Runes MCP Server

### DIFF
--- a/servers/flash-payment-system.yaml
+++ b/servers/flash-payment-system.yaml
@@ -1,0 +1,35 @@
+id: flash_payment_system
+name: Flash Payment System (bUSD1 Runes MCP)
+description: >-
+  First write-capable Bitcoin Runes MCP server. 12 tools to mint, transfer,
+  batch-mint, and list BITCOIN•USD•ONE Runes. bUSD1 USD stablecoin backed 1:1
+  by Runes on Bitcoin Layer 1 with Chainlink Proof of Reserves. Agent swarm
+  coordination and x402 agent-to-agent payments. 99 tests passing.
+author: ElromEvedElElyon
+url: https://github.com/ElromEvedElElyon/flash-payment-system
+category: crypto
+tags:
+  - bitcoin
+  - runes
+  - stablecoin
+  - chainlink
+  - proof-of-reserves
+  - x402
+  - agent-payments
+  - defi
+  - btcfi
+  - ordinals
+installations:
+  - name: Git Clone
+    config: |-
+      {
+        "command": "node",
+        "args": ["dist/src/mcp/server-entry.js"]
+      }
+    prerequisites:
+      - Node.js
+      - Git
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
## Summary
- Adds **flash-payment-system** YAML entry to the MCP registry
- First **write-capable Bitcoin Runes MCP server** with 12 tools
- bUSD1 USD stablecoin backed 1:1 by BITCOIN USD ONE Runes on Bitcoin L1
- Chainlink Proof of Reserves, agent swarm coordination, x402 payments
- 99 tests passing, MIT license

## Server Details
- **Name**: Flash Payment System (bUSD1 Runes MCP)
- **Category**: crypto
- **Transport**: stdio
- **Runtime**: Node.js
- **Tools**: 12 (mint, transfer, batch-mint, list, PoR, swarm, x402)
- **GitHub**: https://github.com/ElromEvedElElyon/flash-payment-system
- **Release**: https://github.com/ElromEvedElElyon/flash-payment-system/releases/tag/v1.0.0
