### PR TITLE
Add IntoDNS.ai MCP server

### DIFF
--- a/servers/intodns_mcp.yaml
+++ b/servers/intodns_mcp.yaml
@@ -1,0 +1,33 @@
+id: intodns_mcp
+name: IntoDNS.ai MCP
+description: >-
+  DNS and email security scanner for AI agents with SPF, DKIM, DMARC, DNSSEC,
+  BIMI, STARTTLS, FCrDNS, blacklists, reports, and citations.
+author: Cobytes
+url: https://github.com/RoscoNL/intodns-mcp-server
+license: MIT
+category: security
+tags:
+  - dns
+  - email-security
+  - deliverability
+  - dmarc
+  - dnssec
+  - bimi
+  - blacklist
+  - security-scanner
+  - citations
+installations:
+  - name: NPX
+    description: Run the IntoDNS.ai MCP server with no API key or signup.
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "intodns-mcp"]
+      }
+    prerequisites:
+      - Node.js
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Adds `intodns-mcp` to the registry.

IntoDNS.ai MCP is an MIT-licensed stdio MCP server for DNS and email security checks, including SPF, DKIM, DMARC, DNSSEC, BIMI, SMTP STARTTLS, FCrDNS, blacklists, report snapshots, and citation guidance.

Install/config:
```json
{
  "command": "npx",
  "args": ["-y", "intodns-mcp"]
}
```

Validation performed locally:
- `npm run validate`
- `npm test`
- `npm run build`