### PR TITLE
Add sverklo (local-first code intelligence MCP)

### DIFF
--- a/servers/sverklo.yaml
+++ b/servers/sverklo.yaml
@@ -1,0 +1,50 @@
+id: sverklo
+name: Sverklo
+description: >-
+  Local-first MCP server for code intelligence — symbol graph, blast-radius
+  analysis, file dependency graphs, code audit, and bi-temporal memory pinned
+  to git SHAs. The only code-intelligence MCP with a published peer-reviewable
+  benchmark (60 tasks, 5 baselines, reproducible). MIT-licensed alternative to
+  Greptile and Sourcegraph Cody. Zero config — `sverklo init` auto-detects
+  Claude Code, Cursor, Windsurf, and Zed.
+author: sverklo
+url: https://github.com/sverklo/sverklo
+category: development
+tags:
+  - code-intelligence
+  - code-search
+  - symbol-graph
+  - blast-radius
+  - pagerank
+  - bm25
+  - tree-sitter
+  - bi-temporal-memory
+  - local-first
+  - greptile-alternative
+  - sourcegraph-alternative
+  - claude-code
+  - cursor
+  - windsurf
+  - zed
+installations:
+  - name: NPX
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "sverklo"]
+      }
+    prerequisites:
+      - Node.js >= 20
+    transports:
+      - stdio
+  - name: Global install
+    config: |-
+      {
+        "command": "sverklo",
+        "args": []
+      }
+    prerequisites:
+      - Node.js >= 20
+      - "npm install -g sverklo"
+    transports:
+      - stdio


### PR DESCRIPTION
Adds [sverklo](https://github.com/sverklo/sverklo) — a local-first MCP server for code intelligence — to the registry under the `development` category.

## Server summary

- **What it does:** Gives Claude Code, Cursor, Windsurf, and Zed 37 MCP tools spanning hybrid search (BM25 + ONNX embedding + PageRank), blast-radius analysis, file-dependency graphs, code audit (god classes, dead code, security patterns), and bi-temporal memory pinned to git SHAs.
- **License:** MIT
- **Hosting:** Local (embedded SQLite + ONNX, no cloud)
- **Languages indexed:** 12 (TypeScript, JavaScript, Python, Go, Rust, Java, C, C++, C#, Ruby, PHP, Swift)
- **Verification:** Public 60-task benchmark across 5 baselines at https://sverklo.com/bench/, reproducible by anyone with `npm run bench`. Peer-reviewable methodology paper at https://doi.org/10.5281/zenodo.19802051.

## Installation

Two installation methods provided in the YAML:

1. **NPX** (zero-setup): `npx -y sverklo`
2. **Global install**: `npm install -g sverklo` then `sverklo`

Both use stdio transport.

## Self-disclosure

I'm the maintainer. Latest release v0.20.1 is on npm.