### PR TITLE
Add NotFair Google Ads MCP to registry

### DIFF
--- a/servers/notfair.yaml
+++ b/servers/notfair.yaml
@@ -1,0 +1,31 @@
+id: notfair
+name: NotFair Google Ads MCP
+description: >-
+  Google Ads MCP server. Connects Claude and AI agents to a Google Ads account:
+  diagnose campaign performance (CPA, ROAS, search-term waste, quality scores),
+  recommend optimizations, and execute approved changes via the Google Ads API
+  with a built-in human-approval gate. Free tier available.
+author: nowork-studio
+url: https://github.com/nowork-studio/toprank
+license: Proprietary
+category: marketing
+tags:
+  - google-ads
+  - advertising
+  - marketing
+  - ppc
+  - campaign-management
+  - paid-search
+installations:
+  - name: Remote (Streamable HTTP)
+    description: Hosted streamable-HTTP MCP server. Sign in at notfair.co to authorize a Google Ads account.
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://notfair.co/api/mcp/google_ads"
+      }
+    prerequisites: []
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
Adds NotFair to the registry. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Manifest follows the schema with a single Remote (Streamable HTTP) installation since it's a hosted server. Happy to adjust the format or fields if you'd prefer.