### PR TITLE
Add Sharpe MCP Server

### DIFF
--- a/servers/sharpe.yaml
+++ b/servers/sharpe.yaml
@@ -1,0 +1,30 @@
+id: sharpe
+name: Sharpe MCP Server
+description: >-
+  MCP server for crypto market intelligence, including funding rates, futures,
+  options, arbitrage, narratives, exchange listings, and news.
+author: Sharpe
+url: https://www.sharpe.ai/docs/mcp-server
+license: MIT
+category: finance
+tags:
+  - crypto
+  - market-data
+  - derivatives
+  - trading
+  - finance
+installations:
+  - name: UVX
+    description: Run the Sharpe MCP server with uvx.
+    config: |-
+      {
+        "command": "uvx",
+        "args": ["sharpe-mcp"]
+      }
+    prerequisites:
+      - Python
+      - uv
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Adds Sharpe MCP Server to the registry as `servers/sharpe.yaml`.

The entry follows the repository schema with a finance category, crypto market-data tags, the public MCP documentation URL, MIT license, and a `uvx sharpe-mcp` stdio installation. The description is scoped to the MCP server's market-data coverage: funding rates, futures, options, arbitrage, narratives, exchange listings, and news.

Website URL: https://www.sharpe.ai/docs/mcp-server
Validation: `npm run validate`, `npm test`, and `git diff --check` pass. `npm ci` completed and reported existing dependency audit findings.
Linear: SHA-193

Disclosure: I work on Sharpe.