### PR TITLE
Add MartinLoop MCP

### DIFF
--- a/servers/martinloop_mcp.yaml
+++ b/servers/martinloop_mcp.yaml
@@ -1,0 +1,29 @@
+id: martinloop_mcp
+name: MartinLoop MCP
+description: >-
+  Governed MCP server for AI coding agents with budgets, verifier gates, and
+  inspectable runs.
+author: Vakeesan Mahalingam and Gobi Shanthan
+url: https://github.com/Keesan12/martin-loop
+license: Apache-2.0
+category: development
+tags:
+  - development
+  - governance
+  - verification
+  - ai-agents
+  - coding
+installations:
+  - name: NPX
+    description: Run the published MartinLoop MCP package with npx.
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "@martinloop/mcp"]
+      }
+    prerequisites:
+      - Node.js
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
## Summary
- add MartinLoop MCP to the community registry
- provide an NPX installation config for the published `@martinloop/mcp` package
- classify it under development with governance and verification oriented tags

## Notes
- this PR follows the server YAML format documented in the repository README
- CI can validate the entry against the registry schema and consistency checks