### PR TITLE
Add Xquik remote MCP server

### DIFF
--- a/servers/xquik.yaml
+++ b/servers/xquik.yaml
@@ -1,0 +1,41 @@
+id: xquik
+name: Xquik
+description: >-
+  Remote MCP server for Xquik's X data platform, with structured access to tweet
+  search, user lookup, follower extraction, monitoring, webhooks, giveaway draws,
+  and confirmation-gated write actions.
+author: Xquik
+url: https://github.com/Xquik-dev/x-twitter-scraper
+license: MIT
+category: social-media
+tags:
+  - x
+  - twitter
+  - social-media
+  - data-extraction
+  - monitoring
+  - webhooks
+  - automation
+installations:
+  - name: Remote
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://xquik.com/mcp",
+        "headers": {
+          "x-api-key": "${XQUIK_API_KEY}"
+        }
+      }
+    prerequisites:
+      - Xquik account
+      - Xquik API key
+    parameters:
+      - name: Xquik API Key
+        key: XQUIK_API_KEY
+        description: API key from the Xquik dashboard account page
+        placeholder: xq_your_api_key
+        required: true
+    transports:
+      - streamable-http
+featured: false
+verified: false

--- a/servers/xquik.yaml
+++ b/servers/xquik.yaml
@@ -1,9 +1,9 @@
 id: xquik
 name: Xquik
 description: >-
-  Remote MCP server for Xquik's X data platform, with structured access to tweet
-  search, user lookup, follower extraction, monitoring, webhooks, giveaway draws,
-  and confirmation-gated write actions.
+  Hosted X data workflows with 118 MCP operations through 2 tools for search,
+  profiles, followers, media, monitors, webhooks, draws, and supported account
+  actions. Not affiliated with X Corp.
 author: Xquik
 url: https://github.com/Xquik-dev/x-twitter-scraper
 license: MIT
@@ -23,7 +23,7 @@ installations:
         "type": "streamable-http",
         "url": "https://xquik.com/mcp",
         "headers": {
-          "x-api-key": "${XQUIK_API_KEY}"
+          "Authorization": "Bearer ${XQUIK_API_KEY}"
         }
       }
     prerequisites:


### PR DESCRIPTION
## Summary

- Add Xquik as a remote Streamable HTTP MCP server.
- Use Xquik public documentation and repository as source truth.
- Document 118 MCP operations through 2 tools.
- Use `Authorization: Bearer ${XQUIK_API_KEY}` for the API key fallback.
- Keep `featured` and `verified` false for maintainer review.

## Validation

- `npm test`: 20 tests passed
- `npm run validate`: all servers valid
- `npm run build`: 38 servers built
- `git diff --check`

## Duplicate Check

- Searched repository contents for Xquik names, domains, and repository aliases.
- PR #20 is an overlapping earlier submission. This PR uses the newer target base and current source-backed metadata, so #20 is being closed as the duplicate.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.