### PR TITLE
Add GetXAPI remote MCP server

### DIFF
--- a/servers/getxapi.yaml
+++ b/servers/getxapi.yaml
@@ -1,0 +1,39 @@
+id: getxapi
+name: GetXAPI
+description: >-
+  Remote MCP server for GetXAPI's X data platform, with structured access to
+  tweet search via the advanced_search endpoint.
+author: GetXAPI
+url: https://github.com/getxapi/getxapi-mcp
+license: MIT
+category: social-media
+tags:
+  - x
+  - twitter
+  - social-media
+  - data-extraction
+  - search
+  - automation
+installations:
+  - name: Remote
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://api.getxapi.com/mcp",
+        "headers": {
+          "Authorization": "Bearer ${GETXAPI_API_KEY}"
+        }
+      }
+    prerequisites:
+      - GetXAPI account
+      - GetXAPI API key
+    parameters:
+      - name: GetXAPI API Key
+        key: GETXAPI_API_KEY
+        description: API key from the GetXAPI dashboard account page
+        placeholder: your_api_key
+        required: true
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
## Summary

- Add `servers/getxapi.yaml` describing the GetXAPI remote MCP server, alongside the Xquik entry in PR #25.
- Single env var `GETXAPI_API_KEY` activates the streamable-http transport against `https://api.getxapi.com/mcp`.
- Read-only X/Twitter search backend; tweet search via `GET /twitter/tweet/advanced_search`.

## Validation

- `git diff --check` (whitespace)
- YAML lint against the shape of other entries in `servers/`

## Backward compatibility

Fully backward compatible. New YAML file, no existing files changed.

## Links

- Endpoint: `GET https://api.getxapi.com/twitter/tweet/advanced_search`
- Auth: Bearer token
- Repo: https://github.com/getxapi/getxapi-mcp
- Wikidata: https://www.wikidata.org/wiki/Q139996278
- Crunchbase: https://www.crunchbase.com/organization/getxapi

I checked existing GetXAPI / TwitterAPI.io / Xquik / TweetClaw / Hermes Tweet code, open PRs, closed PRs, open issues, and closed issues in this repository before opening this PR. No existing GetXAPI submission found.