### PR TITLE
Add Hive Intelligence to registry

### DIFF
--- a/servers/hive_intelligence.yaml
+++ b/servers/hive_intelligence.yaml
@@ -1,0 +1,58 @@
+id: hive_intelligence
+name: Hive Intelligence
+description: >-
+  Managed crypto intelligence MCP for AI agents, covering market data, DeFi
+  analytics, wallet intelligence, token risk, DEX flows, NFTs, infrastructure,
+  and prediction markets.
+author: Hive Intelligence
+url: https://github.com/hive-intel/hive-sdk
+category: data
+tags:
+  - crypto
+  - defi
+  - market-data
+  - wallet-intelligence
+  - token-risk
+  - prediction-markets
+  - mcp
+installations:
+  - name: NPX
+    description: Run the Hive Intelligence stdio MCP server using the published npm package.
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "hive-intelligence@latest"],
+        "env": {
+          "HIVE_API_KEY": "${HIVE_API_KEY}"
+        }
+      }
+    prerequisites:
+      - Node.js 20+
+      - Hive API key
+    parameters:
+      - name: Hive API Key
+        key: HIVE_API_KEY
+        description: API key for Hive Intelligence.
+        placeholder: hive_your_api_key
+    transports:
+      - stdio
+  - name: Remote HTTP
+    description: Connect to the hosted Hive Intelligence MCP endpoint.
+    config: |-
+      {
+        "url": "https://mcp.hiveintelligence.xyz/mcp",
+        "headers": {
+          "Authorization": "Bearer ${HIVE_API_KEY}"
+        }
+      }
+    prerequisites:
+      - Hive API key
+    parameters:
+      - name: Hive API Key
+        key: HIVE_API_KEY
+        description: API key for Hive Intelligence.
+        placeholder: hive_your_api_key
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
Hi ravitemer,

This adds Hive Intelligence as a structured registry entry with both supported ways a client may connect:

- `NPX` for local stdio setup through the published `hive-intelligence` npm package.
- `Remote HTTP` for the hosted MCP endpoint at `https://mcp.hiveintelligence.xyz/mcp`.

I matched this registry's YAML format and parameter model so consumers can replace one `HIVE_API_KEY` placeholder in either configuration. The entry focuses on the parts that are useful for MCP client builders: crypto market data, DeFi analytics, wallet intelligence, token risk, DEX flows, NFTs, infrastructure, and prediction markets.

Validation run locally:

```bash
npm run validate
npm test
```

Both passed.
