### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/servers/twzrd_agent_intel.yaml
+++ b/servers/twzrd_agent_intel.yaml
@@ -5,7 +5,7 @@ description: >-
   Provides free preflight trust checks and paid cryptographically signed V5 trust receipts
   via the x402 micropayment protocol. Streamable-HTTP transport.
 author: twzrd-sol
-url: https://github.com/twzrd-sol/wzrd-final
+url: https://intel.twzrd.xyz
 category: blockchain
 tags:
   - solana

--- a/servers/twzrd_agent_intel.yaml
+++ b/servers/twzrd_agent_intel.yaml
@@ -1,0 +1,30 @@
+id: twzrd_agent_intel
+name: TWZRD Agent Intel
+description: >-
+  Solana-native trust scoring and x402 receipt verification MCP server for AI agents.
+  Provides free preflight trust checks and paid cryptographically signed V5 trust receipts
+  via the x402 micropayment protocol. Streamable-HTTP transport.
+author: twzrd-sol
+url: https://github.com/twzrd-sol/wzrd-final
+category: blockchain
+tags:
+  - solana
+  - trust
+  - x402
+  - micropayments
+  - ai-agents
+  - receipts
+  - identity
+  - web3
+installations:
+  - name: Streamable-HTTP (Remote)
+    description: Connect directly to the hosted TWZRD Agent Intel MCP endpoint
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://intel.twzrd.xyz/mcp"
+      }
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
## Summary

Adds a YAML registry entry for **TWZRD Agent Intel**, a production Solana-native MCP server.

**New file**: `servers/twzrd_agent_intel.yaml`

TWZRD Agent Intel provides:
- Free preflight trust score checks for AI agents
- Paid cryptographically signed V5 trust receipts via x402 micropayment protocol  
- Streamable-HTTP transport (remote hosted endpoint — no local install required)

```yaml
id: twzrd_agent_intel
category: blockchain
tags: [solana, trust, x402, micropayments, ai-agents]
transport: streamable-http
url: https://intel.twzrd.xyz/mcp
```

- **Service**: https://intel.twzrd.xyz  
- **Repo**: https://intel.twzrd.xyz