### PR TITLE
Add BuyWhere MCP server - real-time product search & price comparison (Southeast Asia)

### DIFF
--- a/servers/buywhere.yaml
+++ b/servers/buywhere.yaml
@@ -1,0 +1,55 @@
+id: buywhere
+name: BuyWhere
+description: >-
+  Real-time product search and price comparison MCP server. Search and compare
+  260K+ products across 1,000+ merchants in Southeast Asia — Singapore, Malaysia,
+  Philippines, Thailand, and Indonesia. Built for AI agents doing price research,
+  deal discovery, and product availability checks.
+author: BuyWhere
+url: https://github.com/BuyWhere/buywhere-mcp
+category: ecommerce
+tags:
+  - ecommerce
+  - shopping
+  - price-comparison
+  - product-search
+  - southeast-asia
+  - singapore
+  - lazada
+  - shopee
+  - remote
+installations:
+  - name: NPX
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "@buywhere/mcp-server"],
+        "env": {
+          "BUYWHERE_API_KEY": "${BUYWHERE_API_KEY}"
+        }
+      }
+    prerequisites:
+      - Node.js
+    parameters:
+      - name: BuyWhere API Key
+        key: BUYWHERE_API_KEY
+        placeholder: bw_xxxxxxxxxxxxxxxxxxxxxxxx
+    transports:
+      - stdio
+  - name: Remote (Streamable HTTP)
+    config: |-
+      {
+        "url": "https://mcp.buywhere.ai/mcp",
+        "headers": {
+          "Authorization": "Bearer ${BUYWHERE_API_KEY}"
+        }
+      }
+    prerequisites: []
+    parameters:
+      - name: BuyWhere API Key
+        key: BUYWHERE_API_KEY
+        placeholder: bw_xxxxxxxxxxxxxxxxxxxxxxxx
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
## BuyWhere MCP Server

Adds BuyWhere to the registry — a real-time product search and price comparison MCP server for Southeast Asia.

**Category:** ecommerce

**What it does:**
- Search products across 1,000+ merchants in Singapore, Malaysia, Philippines, Thailand, Indonesia
- Compare prices in real time across Lazada, Shopee, and major retailers
- Get product details, specs, pricing, and availability
- Find best deals and lowest prices for specific queries

**Available transport types:**
- `stdio` (NPX install): `npx -y @buywhere/mcp-server`
- `streamable-http` (remote, no install): `https://mcp.buywhere.ai/mcp`

Free API keys at buywhere.ai/api-keys — instant issuance.

**npm:** `@buywhere/mcp-server` | **GitHub:** https://github.com/BuyWhere/buywhere-mcp