### PR TITLE
Add AccInt MCP server

### DIFF
--- a/servers/accint.yaml
+++ b/servers/accint.yaml
@@ -1,0 +1,36 @@
+id: accint
+name: AccInt
+description: >-
+  Outcome-aware MCP memory server for AI agents that retrieves past work, tracks
+  commitments, and learns from real-world feedback.
+author: maxbaluev
+url: https://github.com/maxbaluev/accreted-intelligence
+category: agent-memory
+tags:
+  - agent-memory
+  - retrieval
+  - commitments
+  - outcome-feedback
+  - mcp
+  - claude-code
+  - codex
+installations:
+  - name: Local binary
+    description: Run AccInt from a locally installed release binary.
+    config: |-
+      {
+        "command": "acc",
+        "args": ["--db", "${ACC_DB}", "mcp"]
+      }
+    prerequisites:
+      - AccInt release binary installed
+    parameters:
+      - name: AccInt Database Path
+        key: ACC_DB
+        description: Absolute path to the local AccInt database file.
+        placeholder: /absolute/path/to/acc.db
+        required: true
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
## Summary
- Add AccInt as a structured MCP registry entry.
- Provide a local-binary stdio install configuration: `acc --db ${ACC_DB} mcp`.
- Omit license metadata rather than guessing while the public repository has no GitHub license metadata.

## Validation
- `npm test`
- `npm run validate`
- `npm run build`
- `git diff --check`
- AccInt GitHub repo link returns HTTP 200
