### PR TITLE
Add Latitude observability MCP server

### DIFF
--- a/servers/latitude.yaml
+++ b/servers/latitude.yaml
@@ -1,0 +1,33 @@
+id: latitude
+name: Latitude
+description: >-
+  Open-source LLM observability and evaluation platform. Read and manage your
+  Latitude workspace — projects, traces, spans, issues, annotations, scores,
+  saved searches, datasets, monitors, and members — directly from your AI agent.
+author: latitude-dev
+url: https://github.com/latitude-dev/latitude-llm
+license: MIT
+category: development
+tags:
+  - observability
+  - llm
+  - tracing
+  - evaluation
+  - monitoring
+  - analytics
+installations:
+  - name: Remote
+    description: >-
+      Remote, OAuth-authenticated streamable HTTP server. On first connect your
+      agent opens a browser to sign in and pick the organization to grant access
+      to — no API key to copy or store.
+    config: |-
+      {
+        "url": "https://api.latitude.so/v1/mcp"
+      }
+    prerequisites:
+      - Latitude account (sign up at https://console.latitude.so/login, or self-host)
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
Adds [Latitude](https://github.com/latitude-dev/latitude-llm) to the registry — an open-source LLM observability and evaluation platform.

The Latitude MCP is a remote, OAuth-authenticated, streamable HTTP server at `https://api.latitude.so/v1/mcp`. It exposes the full Latitude workspace as tools — projects, traces, spans, issues, annotations, scores, saved searches, datasets, monitors, and members. The tool catalog is generated dynamically from the Latitude API.

Auth is browser-based OAuth on first connect (pick an organization in the consent screen) — there's no API key to copy, so the `Remote` installation needs no parameters, mirroring the existing `sentry` Remote entry.

### Validation
- `npm run validate` — all servers valid
- `npm test` — 20/20 passing
- `npm run build` — successful (38 servers)