### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/servers/agentage_memory.yaml
+++ b/servers/agentage_memory.yaml
@@ -1,0 +1,33 @@
+id: agentage_memory
+name: agentage Memory
+description: >-
+  One memory. Every AI. Owned by you. A shared markdown memory layer that Claude,
+  Cursor, and ChatGPT read and write through MCP, mirrored locally as plain .md
+  files you own and can export anytime. Search, read, write, edit, list, and
+  delete memories across every AI client.
+author: agentage
+url: https://memory.agentage.io
+license: Proprietary
+category: knowledge-graph
+tags:
+  - memory
+  - persistent-memory
+  - knowledge-management
+  - markdown
+  - cross-vendor
+  - oauth
+  - remote
+installations:
+  - name: Remote
+    description: Hosted MCP server with OAuth 2.1 + PKCE (Dynamic Client Registration)
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://memory.agentage.io/mcp"
+      }
+    prerequisites:
+      - agentage account
+    transports:
+      - streamable-http
+featured: false
+verified: false

--- a/servers/agentage_memory.yaml
+++ b/servers/agentage_memory.yaml
@@ -1,5 +1,5 @@
 id: agentage_memory
-name: agentage Memory
+name: Agentage Memory
 description: >-
   One memory. Every AI. Owned by you. A shared markdown memory layer that Claude,
   Cursor, and ChatGPT read and write through MCP, mirrored locally as plain .md


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this list's conventions.
