### PR TITLE
Add ax MCP registry entry

### DIFF
--- a/servers/ax.yaml
+++ b/servers/ax.yaml
@@ -1,0 +1,31 @@
+id: ax_mcp
+name: ax
+description: >-
+  Exposes read-only MCP queries over local AI coding-agent sessions, tool calls,
+  skills, costs, and dispatches.
+author: Necmttn
+url: https://github.com/Necmttn/ax
+license: MIT
+category: development
+tags:
+  - ai-coding
+  - agent-observability
+  - telemetry
+  - cost-tracking
+  - session-recall
+  - mcp-server
+installations:
+  - name: Source checkout
+    description: Run ax MCP from a local source checkout
+    config: |-
+      {
+        "command": "apps/axctl/bin/axctl",
+        "args": ["mcp"]
+      }
+    prerequisites:
+      - Bun
+      - ax source checkout
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Adds ax as a structured MCP registry entry.

The entry uses a local source-checkout stdio config for `apps/axctl/bin/axctl mcp` and tags it for AI coding telemetry, cost tracking, and session recall.

Checks:
- `npm test`
- `npm run validate`
- `npm run build`
- `git diff --check`
- focused YAML/schema/config check
- ax repository link check returned 200
- Subagent fit/spec review and copy review passed

---
_Generated with [ax](https://github.com/Necmttn/ax)._
