### PR TITLE
Add AgentServices — x402-paid APIs for AI agents (52 endpoints, 37 MCP tools)

### DIFF
--- a/servers/agentservices.yaml
+++ b/servers/agentservices.yaml
@@ -1,0 +1,43 @@
+id: agentservices
+name: AgentServices
+description: >-
+  Premium APIs for AI agents. Crypto data, market intelligence, on-chain analytics,
+  DeFi strategies, portfolio intelligence, and cross-DEX arbitrage scanning.
+  52 endpoints (40 paid via x402, 12 free). MCP server with 37 tools.
+  Agents discover and pay for data services via USDC micropayments on Base.
+author: vbkotecha
+url: https://github.com/vbkotecha/aiservices-api
+category: finance
+tags:
+  - crypto
+  - market-data
+  - defi
+  - onchain
+  - portfolio
+  - arbitrage
+  - x402
+  - price-feeds
+  - defi-yields
+  - technical-indicators
+installations:
+  - name: Remote
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://agentservices.to/mcp"
+      }
+    prerequisites: []
+    transports:
+      - streamable-http
+  - name: NPX
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "agentservices-mcp"]
+      }
+    prerequisites:
+      - Node.js
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
## AgentServices — Premium APIs for AI Agents

**Website:** https://agentservices.to
**MCP Server:** https://agentservices.to/mcp (streamable-http)
**GitHub:** https://github.com/vbkotecha/aiservices-api

### What is AgentServices?

A paid API platform for AI agents. 52 endpoints covering:
- **Crypto Data** — prices, technical indicators, DeFi yields, whale movements, exchange flows
- **Market Intelligence** — sentiment analysis, trending tokens, news, social signals
- **On-Chain Analytics** — stablecoin flows, correlations, macro indicators
- **Bundled Intelligence** — portfolio analysis ($0.10), DeFi strategy reports ($0.25), market pulse ($0.05), on-chain overview ($0.15), cross-DEX arbitrage scanning ($0.08)
- **Inference** — GPT models via x402 ($0.03/call)
- **Free Tier** — crypto prices, fear & greed index, trending tokens, gas prices, news, social trending

### Pricing
- 12 endpoints free (no payment required)
- 40 endpoints paid via x402 (USDC on Base, $0.01–$0.25 per call)
- MCP server has 37 tools

### Transport
- **Remote:** streamable-http at https://agentservices.to/mcp
- **NPX:** `npx agentservices-mcp` (coming soon, package built)

### Why add to this registry?
AgentServices is one of the largest x402-native API platforms for AI agents. Adding it to the community registry helps agents discover paid data services and market intelligence capabilities.