### PR TITLE
Add nika (read-only AI workflow oracle)

### DIFF
--- a/servers/nika.yaml
+++ b/servers/nika.yaml
@@ -1,0 +1,25 @@
+id: nika
+name: Nika
+description: >-
+  Read-only oracle for the Nika AI workflow engine. Agents validate
+  .nika.yaml workflow DAGs, get findings explained with fix guidance, browse
+  examples and schema, and see an honest cost estimate — all before a single
+  token is spent. No execution and no mutation over MCP by design.
+author: supernovae-st
+url: https://github.com/supernovae-st/nika
+category: development
+tags:
+  - workflow
+  - yaml
+  - validation
+  - cost-estimation
+  - rust
+installations:
+  - name: Binary (brew or release tarball)
+    config: |-
+      {
+        "command": "nika",
+        "args": ["mcp"]
+      }
+    prerequisites:
+      - nika binary (brew install supernovae-st/tap/nika)


### PR DESCRIPTION
Adds **nika** — the read-only MCP oracle of the Nika workflow engine (single Rust binary, AGPL-3.0).

Agents use it to validate `.nika.yaml` workflow files, get findings explained, browse schema/examples, and see an honest cost estimate before running anything. No execution and no mutation over MCP by design (threat model documented in-repo). Install is a binary (brew/tarball with SHA256SUMS), config stanza is in the YAML.

Disclosure: I'm the author.
