### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/servers/autoposting.yaml
+++ b/servers/autoposting.yaml
@@ -1,0 +1,34 @@
+id: autoposting
+name: Autoposting
+description: >-
+  Hosted MCP server for social media publishing. Draft and rewrite posts,
+  generate ideas with AI agents, build carousels, clip and render video, search
+  a knowledge base, manage brands and webhooks, and schedule or publish to X,
+  LinkedIn, Instagram, Threads and YouTube. Authenticates with OAuth 2.1
+  Dynamic Client Registration, so there is nothing to install locally.
+author: Autoposting-ai
+url: https://github.com/Autoposting-ai/autoposting-mcp
+license: MIT
+category: social-media
+tags:
+  - social-media
+  - marketing
+  - content-generation
+  - scheduling
+  - automation
+  - video
+  - ai-agents
+  - productivity
+installations:
+  - name: Remote
+    description: Connect over Streamable HTTP with OAuth 2.1 Dynamic Client Registration
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://app.autoposting.ai/mcp"
+      }
+    prerequisites: []
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
Adds `servers/autoposting.yaml` — a hosted MCP server for social media publishing: draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube.

- Endpoint: `https://app.autoposting.ai/mcp`
- Transport: `streamable-http`, authenticated with OAuth 2.1 Dynamic Client Registration — no parameters or prerequisites needed, nothing to install locally.
- Docs: https://docs.autoposting.ai/mcp/overview
- Published in the official MCP registry as `ai.autoposting/autoposting`.

Validated locally with `npm run validate` and `npm test` — all green.
