### PR TITLE
Add Agent QA MCP server

### DIFF
--- a/servers/agent_qa.yaml
+++ b/servers/agent_qa.yaml
@@ -1,0 +1,26 @@
+id: agent_qa
+name: Agent QA
+description: Source-available QA harness for natural-language web and mobile regression tests, exposed through a local stdio MCP server.
+author: Vostride
+url: https://github.com/vostride/agent-qa
+license: FSL-1.1-ALv2
+category: development
+tags:
+  - testing
+  - quality-assurance
+  - browser-automation
+  - mobile-testing
+installations:
+  - name: NPX
+    description: Run the Agent QA MCP server over stdio
+    config: |
+      {
+        "command": "npx",
+        "args": ["-y", "agent-qa@0.1.21", "mcp"]
+      }
+    prerequisites:
+      - Node.js 24 or newer
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) as a structured local stdio MCP server.

The definition pins the published `agent-qa@0.1.21` package, starts its documented `mcp` subcommand with NPX, records the Node.js 24 prerequisite, and labels the license `FSL-1.1-ALv2`. It leaves both maintainer-controlled quality flags false.

## Validation

- confirmed Agent QA was not already listed or proposed by this account
- `npm test` passes all 20 tests
- `npm run validate` reports all server definitions valid
- `npm run build` processes Agent QA and builds 38 servers
- `npx -y agent-qa@0.1.21 mcp` starts and remains available for stdio client messages
- `git diff --check` passes

Disclosure: I am affiliated with Agent QA. Agent QA uses the source-available FSL-1.1-ALv2 license, not an OSI-approved open-source license; each release converts to Apache-2.0 after two years. The CLI has no software fee for permitted use, while configured model, browser, or device-provider usage may cost money.
