### PR TITLE
Add Pocket Drives public MCP server

### DIFF
--- a/servers/pocket_drives.yaml
+++ b/servers/pocket_drives.yaml
@@ -1,0 +1,27 @@
+id: pocket_drives
+name: Pocket Drives
+description: >-
+  Search peer-to-peer luxury, exotic, and EV rentals from independent hosts.
+  Remote Streamable HTTP at https://pocketdrives.ai/mcp, no authentication required.
+author: PocketList Inc
+url: https://github.com/RevList/pocket-drives-mcp
+category: travel
+tags:
+  - travel
+  - car-rental
+  - luxury
+  - marketplace
+  - ev
+installations:
+  - name: Remote (Streamable HTTP)
+    description: Public Streamable HTTP endpoint. No authentication required.
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://pocketdrives.ai/mcp"
+      }
+    prerequisites: []
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
Add Pocket Drives, a public remote Streamable HTTP MCP for searching peer-to-peer luxury, exotic, and EV rentals from independent hosts.

- Endpoint: https://pocketdrives.ai/mcp (no auth)
- Tools: https://pocketdrives.ai/mcp/tools
- Repo: https://github.com/RevList/pocket-drives-mcp
- Format matches existing remote-only entries (e.g. bgpt.yaml / context7 Remote)
- License omitted (source repo has no LICENSE file)
- featured/verified left false

Disclosure: I am affiliated with PocketList Inc / Pocket Drives.