### PR TITLE
Add Famulor to registry

### DIFF
--- a/servers/famulor.yaml
+++ b/servers/famulor.yaml
@@ -1,0 +1,26 @@
+id: famulor
+name: Famulor
+description: Operates AI assistants and omnichannel communication workflows, including conversation history, calls, campaigns, messaging, knowledge, and automations through Famulor's hosted MCP server.
+author: BEK Service GmbH
+url: https://github.com/bekservice/Famulor-MCP
+category: productivity
+tags:
+  - voice-ai
+  - assistants
+  - communication
+  - automation
+installations:
+  - name: Remote
+    description: Connect to Famulor's hosted MCP server using browser OAuth.
+    config: |
+      {
+        "type": "streamable-http",
+        "url": "https://app.famulor.io/mcp"
+      }
+    prerequisites:
+      - Famulor account
+      - MCP client with browser OAuth support
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
## Summary

Adds Famulor as a hosted Streamable HTTP MCP server using browser OAuth.

## Validation

- Confirmed no existing Famulor server or open Famulor PR
- Verified the endpoint returns the expected OAuth challenge and RFC 9728 metadata
- Ran `npm run all`: 20 tests passed, schema validation passed, and registry build passed
- Ran `git diff --check`

The optional `license` field is deliberately omitted because the linked server repository is proprietary/source-available.