### PR TITLE
feat: add SandBase CLI MCP server

### DIFF
--- a/servers/sandbase_cli.yaml
+++ b/servers/sandbase_cli.yaml
@@ -1,0 +1,30 @@
+id: sandbase_cli
+name: SandBase CLI
+description: >-
+  Secure local stdio MCP bridge for AI clients to discover, inspect, and run
+  models and APIs from a catalog of 2,000+ AI models.
+author: SandBase
+url: https://github.com/sandbaseai/cli
+license: Apache-2.0
+category: developer-tools
+tags:
+  - model-routing
+  - ai-gateway
+  - cli
+  - model-context-protocol
+  - local-first
+installations:
+  - name: NPX
+    description: Install the SandBase CLI globally, then authorize and configure an MCP client.
+    config: |-
+      {
+        "command": "npx",
+        "args": ["-y", "@sandbaseai/cli", "connect"]
+      }
+    prerequisites:
+      - Node.js
+      - Run `sandbase connect` (or the equivalent npx command) to authorize the local bridge.
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
## Summary
- add SandBase CLI as a developer-tools MCP server
- include an NPX stdio installation config and transport metadata
- link the canonical repository and Apache-2.0 license

SandBase CLI provides a secure local bridge for AI clients to discover, inspect, and run APIs/models across a 2,000+ model catalog.

- Repository: https://github.com/sandbaseai/cli
- Official MCP Registry: https://registry.modelcontextprotocol.io/?q=io.github.sandbaseai%2Fcli
- npm: https://www.npmjs.com/package/@sandbaseai/cli

Validation performed:
- `npm test` (20 tests passed)
- `npm run validate` (all servers valid)
- `npm run build` (registry generated successfully)
