### PR TITLE
Add Process Street to the MCP registry

### DIFF
--- a/servers/process_street.yaml
+++ b/servers/process_street.yaml
@@ -1,0 +1,32 @@
+id: process_street
+name: Process Street
+description: >-
+  Connect AI agents to Process Street workflows, tasks, runs, data sets, and
+  operational records through the official hosted MCP server.
+author: Process Street
+url: https://github.com/process-street/process-street-mcp
+category: productivity
+tags:
+  - workflow-automation
+  - business-process-management
+  - compliance
+  - operations
+  - productivity
+installations:
+  - name: Remote Streamable HTTP
+    description: >-
+      Connect to the official hosted Process Street MCP server. Supported
+      clients can use interactive authorization. Clients with custom headers
+      can use a Process Street API key as a bearer token.
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://mcp.process.st/"
+      }
+    prerequisites:
+      - Compatible MCP client
+      - Process Street account or Process Street API key
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
## Summary

Add Process Street's official hosted Streamable HTTP MCP server.

## Verification

- Public discovery repository: https://github.com/process-street/process-street-mcp
- Official documentation: https://www.process.st/help/docs/mcp-server/
- Official Registry record: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.process-street%2Fprocess-street-mcp
- Remote endpoint: https://mcp.process.st/

The contribution adds one YAML definition and no credentials. The entry remains `featured: false` and `verified: false` for maintainers to review.