### PR TITLE
Add ParlayAPI stdio installation configurations

### DIFF
--- a/servers/parlayapi.yaml
+++ b/servers/parlayapi.yaml
@@ -1,0 +1,49 @@
+id: parlayapi
+name: ParlayAPI
+description: Sports odds, player props, public discovery and account usage for private workflows. Use your own account key for account tools; allowances and API terms apply. Signup, login-email, checkout-link and preference tools require explicit approval. Software sharing does not grant data distribution rights.
+author: JacobiusMakes
+url: https://github.com/JacobiusMakes/parlay-api-mcp
+license: MIT
+category: data
+tags:
+  - sports
+  - odds
+  - python
+installations:
+  - name: UVX - public discovery
+    description: Start without an account key for public discovery and tool metadata. Account tools require your own key.
+    config: |
+      {
+        "command": "uvx",
+        "args": ["--from", "parlayapi-mcp==0.3.5", "parlayapi-mcp"],
+        "env": {"PARLAYAPI_BASE_URL": "https://parlay-api.com"}
+      }
+    prerequisites:
+      - uv (provides uvx)
+      - Python 3.10 or newer
+    transports:
+      - stdio
+  - name: UVX - your account
+    description: Set PARLAYAPI_KEY in your environment before starting Neovim and keep the variable placeholder in the JSON editor. Account allowances apply.
+    config: |
+      {
+        "command": "uvx",
+        "args": ["--from", "parlayapi-mcp==0.3.5", "parlayapi-mcp"],
+        "env": {
+          "PARLAYAPI_BASE_URL": "https://parlay-api.com",
+          "PARLAYAPI_KEY": "${PARLAYAPI_KEY}"
+        }
+      }
+    prerequisites:
+      - uv (provides uvx)
+      - Python 3.10 or newer
+      - Your own ParlayAPI account key
+    parameters:
+      - name: Your ParlayAPI account key
+        key: PARLAYAPI_KEY
+        description: Your own key from https://parlay-api.com/dashboard. Keep the variable reference to avoid writing the key into the JSON configuration. Do not use a shared community key.
+        required: true
+    transports:
+      - stdio
+featured: false
+verified: false

--- a/servers/parlayapi.yaml
+++ b/servers/parlayapi.yaml
@@ -15,7 +15,7 @@ installations:
     config: |
       {
         "command": "uvx",
-        "args": ["--from", "parlayapi-mcp==0.3.5", "parlayapi-mcp"],
+        "args": ["--from", "parlayapi-mcp==0.3.6", "parlayapi-mcp"],
         "env": {"PARLAYAPI_BASE_URL": "https://parlay-api.com"}
       }
     prerequisites:
@@ -28,7 +28,7 @@ installations:
     config: |
       {
         "command": "uvx",
-        "args": ["--from", "parlayapi-mcp==0.3.5", "parlayapi-mcp"],
+        "args": ["--from", "parlayapi-mcp==0.3.6", "parlayapi-mcp"],
         "env": {
           "PARLAYAPI_BASE_URL": "https://parlay-api.com",
           "PARLAYAPI_KEY": "${PARLAYAPI_KEY}"


### PR DESCRIPTION
## Change

Add ParlayAPI with two stdio installation configurations for the published `parlayapi-mcp==0.3.5` package: public discovery without key fields, and account tools using the user's `PARLAYAPI_KEY` environment variable. Both use explicit `uvx --from` arguments. `featured` and `verified` remain false.

The account configuration retains the variable reference in MCP Hub's JSON editor. Users supply their own environment value instead of writing a key into configuration. Copy documents account allowances, action approval, and data distribution rights without coverage or outcome guarantees.

## Validation

- `npm test -- --maxWorkers=1`: 20 tests passed.
- `npm run validate`: all definitions passed.
- `npm run build`: generated 38 entries including this addition.
- Repository metadata, live registry JSON, and issue/PR search had no ParlayAPI match before this submission.
- Reviewed the actual install editor and executed the actual runtime EnvResolver body in an isolated VM with a fake environment: public configuration works without a key, the account placeholder resolves, missing account keys fail clearly, the source retains its placeholder, and no log messages are emitted. No real credentials or network calls were used.
- The exact pinned uvx command previously completed MCP initialization and listed 22 tools without an account key or tool calls. This is not a claim of native Neovim installation testing or maintainer verification.

Ready for maintainer review.
