### PR TITLE
Add Base2026 public Streamable HTTP MCP

### DIFF
--- a/servers/base2026.yaml
+++ b/servers/base2026.yaml
@@ -1,0 +1,29 @@
+id: base2026
+name: Base2026 Research MCP
+description: >-
+  Read-only public research and SEO evidence tools over a hosted Streamable HTTP
+  endpoint, including source search and retrieval, creator and topic lookups,
+  topic signals, and a public data manifest.
+author: offflinerpsy
+url: https://github.com/offflinerpsy/base2026
+license: Apache-2.0
+category: research
+tags:
+  - research
+  - seo
+  - evidence
+  - search
+  - streamable-http
+installations:
+  - name: Remote
+    description: Connect to the public read-only endpoint; no local runtime or API key is required.
+    config: |-
+      {
+        "type": "streamable-http",
+        "url": "https://base2026.dev/api/mcp"
+      }
+    prerequisites: []
+    transports:
+      - streamable-http
+featured: false
+verified: false


### PR DESCRIPTION
## Summary
- add Base2026 as a public read-only MCP server entry
- use the documented stateless Streamable HTTP endpoint at https://base2026.dev/api/mcp
- include the official Apache-2.0 source repository and no local runtime/API-key prerequisites

## Sources
- Repository: https://github.com/offflinerpsy/base2026
- MCP integration documentation: https://github.com/offflinerpsy/base2026/blob/main/docs/public-pages/10_MCP_FOR_AI_AGENTS.md
- Endpoint: https://base2026.dev/api/mcp

## Validation
- `npm test` (20 tests passed)
- `npm run validate` (all server definitions valid)
- `npm run build` (38 servers processed)
