### PR TITLE
Add Cohesivity MCP registry entry

### DIFF
--- a/servers/cohesivity.yaml
+++ b/servers/cohesivity.yaml
@@ -31,7 +31,7 @@ installations:
         "args": ["${COHESIVITY_PLUGIN_PATH}/mcp/project-bootstrap.mjs"]
       }
     prerequisites:
-      - Node.js 20 or newer
+      - Node.js 18 or newer
       - A local checkout of https://github.com/cohesivity-org/cohesivity-plugin
     parameters:
       - name: Cohesivity plugin checkout

--- a/servers/cohesivity.yaml
+++ b/servers/cohesivity.yaml
@@ -1,0 +1,44 @@
+id: cohesivity
+name: Cohesivity
+description: "cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402."
+author: Cohesivity
+url: https://github.com/cohesivity-org/cohesivity-plugin
+license: MIT
+category: development
+tags:
+  - backend
+  - infrastructure
+  - postgres
+  - hosting
+  - email
+installations:
+  - name: Remote
+    description: OAuth-protected account management over Streamable HTTP; use Local for anonymous project provisioning.
+    config: |-
+      {
+        "url": "https://cohesivity.ai/mcp/manage"
+      }
+    prerequisites:
+      - An MCP client supporting Streamable HTTP and OAuth sign-in
+      - Sign in to Cohesivity through the client's OAuth flow
+    transports:
+      - streamable-http
+  - name: Local
+    description: Run the local project MCP from a checkout of cohesivity-org/cohesivity-plugin; tenant creation requires explicit confirmation.
+    config: |-
+      {
+        "command": "node",
+        "args": ["${COHESIVITY_PLUGIN_PATH}/mcp/project-bootstrap.mjs"]
+      }
+    prerequisites:
+      - Node.js 20 or newer
+      - A local checkout of https://github.com/cohesivity-org/cohesivity-plugin
+    parameters:
+      - name: Cohesivity plugin checkout
+        key: COHESIVITY_PLUGIN_PATH
+        description: Absolute path to the repository checkout, without a trailing slash
+        placeholder: /absolute/path/to/cohesivity-plugin
+    transports:
+      - stdio
+featured: false
+verified: false


### PR DESCRIPTION
Adds `servers/cohesivity.yaml` in the existing schema, following the single-file submission pattern of Commune (#4) and the Remote configuration used by Sentry.

cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.

Two connection methods are explicit:

- Remote: `https://cohesivity.ai/mcp/manage`, Streamable HTTP with OAuth-capable client sign-in.
- Local: `node` running `mcp/project-bootstrap.mjs` from a source checkout, with a declared absolute-path parameter. This supports anonymous project provisioning after explicit confirmation.

The local configuration starts an MCP server; it does not use the tenant bootstrap installer as if it were a long-running server. `featured` and `verified` remain false. Plugin and skill installation instructions remain in the linked repository.

Verification:

- `npm run validate` passed for all entries.
- `npm test` passed: 20 tests across 3 files.
- The source local server answered `initialize` and `tools/list`, including `create_tenant`; no tenant or resource mutations were invoked.
- Exact description and `git diff --check` passed.

I maintain Cohesivity.
